### PR TITLE
serverTimezone is missing in connection string.

### DIFF
--- a/scripts/om.sh
+++ b/scripts/om.sh
@@ -27,7 +27,7 @@ if [ "${OM_TYPE}" == "min" ]; then
 			sed -i "s|localhost:1433;databaseName=openmeetings|${OM_DB_HOST}:${OM_DB_PORT};databaseName=${OM_DB_NAME}|g" ${DB_CFG_HOME}/persistence.xml
 		;;
 		mysql)
-			sed -i "s|localhost:3306/openmeetings|${OM_DB_HOST}:${OM_DB_PORT}/${OM_DB_NAME}|g" ${DB_CFG_HOME}/persistence.xml
+			sed -i "s|localhost:3306/openmeetings?|${OM_DB_HOST}:${OM_DB_PORT}/${OM_DB_NAME}?serverTimezone=UTC\&amp;|g" ${DB_CFG_HOME}/persistence.xml
 		;;
 		postgresql)
 			sed -i "s|localhost:5432/openmeetings|${OM_DB_HOST}:${OM_DB_PORT}/${OM_DB_NAME}|g" ${DB_CFG_HOME}/persistence.xml


### PR DESCRIPTION
when using `min`, OM can't connect to MySQL database. It will solve by adding `serverTimezone` in connection string, according to https://openmeetings.apache.org/MySQLConfig.html
since it's not in `mysql_persistence.xml`, it should be add manually.  